### PR TITLE
[ADD] PasswordResetView to reset password (BACKEND ONLY FUNCTION)

### DIFF
--- a/appointments/tests.py
+++ b/appointments/tests.py
@@ -1065,8 +1065,6 @@ class AppointmentDetailTest(TestCase):
         client  = Client()
         headers = {"HTTP_Authorization" : self.token}
 
-        appointment_id = Appointment.objects.get(id=1)
-
         response = client.get(f'/appointments/1', **headers, content_type='application/json')
 
         self.assertEqual(response.status_code, 200)
@@ -1081,4 +1079,15 @@ class AppointmentDetailTest(TestCase):
                     "appointment_date": "2022-08-01(월) 오후 2:00"
                 }
             }
+        )
+
+    def test_fail_appointment_does_not_exist(self):
+        client  = Client()
+        headers = {"HTTP_Authorization" : self.token}
+
+        response = client.get(f'/appointments/2', **headers, content_type='application/json')
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(),
+            {'message' : 'APPOINTMENT_DOES_NOT_EXIST'}
         )

--- a/appointments/tests.py
+++ b/appointments/tests.py
@@ -692,7 +692,7 @@ class AppointmentDetailTest(TestCase):
 
         AppointmentImage.objects.create(
                 id              = 1,
-                wound_img       = "ouch.png",
+                wound_img       = "wound_img/ouch.png",
                 appointment_id  = appointment.id
         )
 

--- a/appointments/views.py
+++ b/appointments/views.py
@@ -121,7 +121,7 @@ class AppointmentDetailView(View, DateTimeFormat):
             return JsonResponse({'result' : appointment_detail}, status=200)
         
         except Appointment.DoesNotExist:
-            return JsonResponse({'APPOINTMENT_DOES_NOT_EXIST'}, status=404)
+            return JsonResponse({'message' : 'APPOINTMENT_DOES_NOT_EXIST'}, status=404)
 
 class CancellationView(View):
     @login_decorator

--- a/users/tests.py
+++ b/users/tests.py
@@ -314,3 +314,175 @@ class CheckDuplicateEmailIntegrityTest(TransactionTestCase):
         self.assertEqual(response.json(), {
             'message': "EMAIL_IS_ALREADY_REGISTERED"
         }) 
+
+class PasswordResetTest(TestCase, Validation):
+    def setUp(self):
+        CustomUser.objects.create_user(
+            name      = 'john',
+            email     = 'john@gmail.com',
+            password  = 'john1234',
+            is_doctor = 'False'            
+        )
+
+    def tearDown(self):
+        CustomUser.objects.all().delete()
+
+    def test_success_change_password_success_login(self):
+        client = Client()
+        old_user = {
+            'email' : 'john@gmail.com',
+            'password' : 'john1234'
+        }
+        data = {
+            'email' : 'john@gmail.com',
+            'password' : 'john7980'
+        }
+        headers  = {"HTTP_TYPE_OF_APPLICATION" : "web"}
+        email = data['email']
+        new_password = data['password']
+
+        user = CustomUser.objects.get(email=email)
+
+        # Check login works with old user
+        response = client.post('/users/login', json.dumps(old_user), content_type='application/json', **headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+                'message'     : 'SUCCESS_LOGIN',
+                "access_token": self.generate_jwt(user),
+                'user_id'     : user.id,
+                'user_name'   : user.name
+            })
+        
+        # Check password reset
+        response = client.post('/users/password_reset', json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json(), {
+            'message' : 'PASSWORD_CHANGED_SUCCESSFULLY',
+            'user_name'   : user.name,
+            'new_password' : new_password,
+            }) 
+
+        # Check login works with updated credentials
+        response = client.post('/users/login', json.dumps(data), content_type='application/json', **headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+                'message'     : 'SUCCESS_LOGIN',
+                "access_token": self.generate_jwt(user),
+                'user_id'     : user.id,
+                'user_name'   : user.name
+            })
+
+    def test_success_change_password_fail_login(self):    
+        client = Client()
+        old_user = {
+            'email' : 'john@gmail.com',
+            'password' : 'john1234'
+        }
+        data = {
+            'email' : 'john@gmail.com',
+            'password' : 'john7980'
+        }
+
+        headers  = {"HTTP_TYPE_OF_APPLICATION" : "web"}
+        email = data['email']
+        new_password = data['password']
+
+        user = CustomUser.objects.get(email=email)
+
+        # Check login works with old user
+        response = client.post('/users/login', json.dumps(old_user), content_type='application/json', **headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+                'message'     : 'SUCCESS_LOGIN',
+                "access_token": self.generate_jwt(user),
+                'user_id'     : user.id,
+                'user_name'   : user.name
+            })
+        
+        # Check password reset
+        response = client.post('/users/password_reset', json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json(), {
+            'message' : 'PASSWORD_CHANGED_SUCCESSFULLY',
+            'user_name'   : user.name,
+            'new_password' : new_password,
+            }) 
+
+        # Check login fails with old user credentials
+        response = client.post('/users/login', json.dumps(old_user), content_type='application/json', **headers)
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json(), {'message' : 'WRONG_EMAIL_OR_PASSWORD'})
+
+    def test_fail_change_password_success_login(self):
+        client = Client()
+        old_user = {
+            'email' : 'john@gmail.com',
+            'password' : 'john1234'
+        }
+        data = {
+            'email' : 'john@gmail.com',
+            'password' : 'john7980'
+        }
+
+        headers  = {"HTTP_TYPE_OF_APPLICATION" : "web"}
+        email = data['email']
+        new_password = data['password']
+
+        user = CustomUser.objects.get(email=email)
+
+        # Check login works with old user
+        response = client.post('/users/login', json.dumps(old_user), content_type='application/json', **headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+                'message'     : 'SUCCESS_LOGIN',
+                "access_token": self.generate_jwt(user),
+                'user_id'     : user.id,
+                'user_name'   : user.name
+            })
+        
+        # Check password reset
+        response = client.post('/users/password_reset', json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json(), {
+            'message' : 'PASSWORD_CHANGED_SUCCESSFULLY',
+            'user_name'   : user.name,
+            'new_password' : new_password,
+            }) 
+
+        # Check login fails with old user credentials
+        response = client.post('/users/login', json.dumps(old_user), content_type='application/json', **headers)
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json(), {'message' : 'WRONG_EMAIL_OR_PASSWORD'})
+
+    def test_fail_user_does_not_exist(self):
+        client = Client()
+        data = {
+            'email' : 'brian@gmail.com',
+            'password' : 'brian1234'
+        }
+        
+        # Check password reset
+        response = client.post('/users/password_reset', json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'message' : 'NO_USER_EXISTS_WITH_THIS_EMAIL'}) 
+
+    def test_fail_user_invalid_password_form(self):
+        client = Client()
+        data = {
+            'email' : 'john@gmail.com',
+            'password' : 'john1'
+        }
+        
+        # Check password reset
+        response = client.post('/users/password_reset', json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.json(), {"message": "Enter a valid password."}) 
+

--- a/users/tests.py
+++ b/users/tests.py
@@ -315,7 +315,7 @@ class CheckDuplicateEmailIntegrityTest(TransactionTestCase):
             'message': "EMAIL_IS_ALREADY_REGISTERED"
         }) 
 
-class PasswordResetTest(TestCase, Validation):
+class PasswordChangeTest(TestCase, Validation):
     def setUp(self):
         CustomUser.objects.create_user(
             name      = 'john',
@@ -329,22 +329,27 @@ class PasswordResetTest(TestCase, Validation):
 
     def test_success_change_password_success_login(self):
         client = Client()
-        old_user = {
+        old_data = {
             'email' : 'john@gmail.com',
             'password' : 'john1234'
         }
-        data = {
+        change_data = {
+            'email' : 'john@gmail.com',
+            'old_password' : 'john1234',
+            'new_password' : 'john7980'
+        }
+        new_data = {
             'email' : 'john@gmail.com',
             'password' : 'john7980'
         }
         headers  = {"HTTP_TYPE_OF_APPLICATION" : "web"}
-        email = data['email']
-        new_password = data['password']
+        email = old_data['email']
+        new_password = change_data['new_password']
 
         user = CustomUser.objects.get(email=email)
 
         # Check login works with old user
-        response = client.post('/users/login', json.dumps(old_user), content_type='application/json', **headers)
+        response = client.post('/users/login', json.dumps(old_data), content_type='application/json', **headers)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {
@@ -354,8 +359,8 @@ class PasswordResetTest(TestCase, Validation):
                 'user_name'   : user.name
             })
         
-        # Check password reset
-        response = client.post('/users/password_reset', json.dumps(data), content_type='application/json')
+        # Check password change
+        response = client.post('/users/password_change', json.dumps(change_data), content_type='application/json')
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json(), {
@@ -365,7 +370,7 @@ class PasswordResetTest(TestCase, Validation):
             }) 
 
         # Check login works with updated credentials
-        response = client.post('/users/login', json.dumps(data), content_type='application/json', **headers)
+        response = client.post('/users/login', json.dumps(new_data), content_type='application/json', **headers)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {
@@ -381,14 +386,15 @@ class PasswordResetTest(TestCase, Validation):
             'email' : 'john@gmail.com',
             'password' : 'john1234'
         }
-        data = {
+        change_data = {
             'email' : 'john@gmail.com',
-            'password' : 'john7980'
+            'old_password' : 'john1234',
+            'new_password' : 'john7980'
         }
 
         headers  = {"HTTP_TYPE_OF_APPLICATION" : "web"}
-        email = data['email']
-        new_password = data['password']
+        email = old_user['email']
+        new_password = change_data['new_password']
 
         user = CustomUser.objects.get(email=email)
 
@@ -404,7 +410,7 @@ class PasswordResetTest(TestCase, Validation):
             })
         
         # Check password reset
-        response = client.post('/users/password_reset', json.dumps(data), content_type='application/json')
+        response = client.post('/users/password_change', json.dumps(change_data), content_type='application/json')
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json(), {
@@ -422,11 +428,12 @@ class PasswordResetTest(TestCase, Validation):
         client = Client()
         data = {
             'email' : 'brian@gmail.com',
-            'password' : 'brian1234'
+            'old_password' : 'brian1234',
+            'new_password' : 'brain8790'
         }
         
         # Check password reset
-        response = client.post('/users/password_reset', json.dumps(data), content_type='application/json')
+        response = client.post('/users/password_change', json.dumps(data), content_type='application/json')
 
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json(), {'message' : 'NO_USER_EXISTS_WITH_THIS_EMAIL'}) 
@@ -435,11 +442,12 @@ class PasswordResetTest(TestCase, Validation):
         client = Client()
         data = {
             'email' : 'john@gmail.com',
-            'password' : 'john1'
+            'old_password' : 'john1234',
+            'new_password' : 'john1'
         }
         
         # Check password reset
-        response = client.post('/users/password_reset', json.dumps(data), content_type='application/json')
+        response = client.post('/users/password_change', json.dumps(data), content_type='application/json')
 
         self.assertEqual(response.json(), {"message": "Enter a valid password."}) 
 

--- a/users/tests.py
+++ b/users/tests.py
@@ -428,7 +428,7 @@ class PasswordResetTest(TestCase, Validation):
         # Check password reset
         response = client.post('/users/password_reset', json.dumps(data), content_type='application/json')
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json(), {'message' : 'NO_USER_EXISTS_WITH_THIS_EMAIL'}) 
 
     def test_fail_user_invalid_password_form(self):

--- a/users/tests.py
+++ b/users/tests.py
@@ -360,7 +360,7 @@ class PasswordResetTest(TestCase, Validation):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json(), {
             'message' : 'PASSWORD_CHANGED_SUCCESSFULLY',
-            'user_name'   : user.name,
+            'email'   : user.email,
             'new_password' : new_password,
             }) 
 
@@ -409,50 +409,7 @@ class PasswordResetTest(TestCase, Validation):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json(), {
             'message' : 'PASSWORD_CHANGED_SUCCESSFULLY',
-            'user_name'   : user.name,
-            'new_password' : new_password,
-            }) 
-
-        # Check login fails with old user credentials
-        response = client.post('/users/login', json.dumps(old_user), content_type='application/json', **headers)
-        self.assertEqual(response.status_code, 401)
-        self.assertEqual(response.json(), {'message' : 'WRONG_EMAIL_OR_PASSWORD'})
-
-    def test_fail_change_password_success_login(self):
-        client = Client()
-        old_user = {
-            'email' : 'john@gmail.com',
-            'password' : 'john1234'
-        }
-        data = {
-            'email' : 'john@gmail.com',
-            'password' : 'john7980'
-        }
-
-        headers  = {"HTTP_TYPE_OF_APPLICATION" : "web"}
-        email = data['email']
-        new_password = data['password']
-
-        user = CustomUser.objects.get(email=email)
-
-        # Check login works with old user
-        response = client.post('/users/login', json.dumps(old_user), content_type='application/json', **headers)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {
-                'message'     : 'SUCCESS_LOGIN',
-                "access_token": self.generate_jwt(user),
-                'user_id'     : user.id,
-                'user_name'   : user.name
-            })
-        
-        # Check password reset
-        response = client.post('/users/password_reset', json.dumps(data), content_type='application/json')
-
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.json(), {
-            'message' : 'PASSWORD_CHANGED_SUCCESSFULLY',
-            'user_name'   : user.name,
+            'email'   : user.email,
             'new_password' : new_password,
             }) 
 

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from users.views import SignUpView, LoginView, CheckDuplicateEmailView
+from users.views import PasswordResetView, SignUpView, LoginView, CheckDuplicateEmailView
 
 urlpatterns = [
     path('/signup', SignUpView.as_view()),
     path('/login', LoginView.as_view()),
-    path('/check_duplicate', CheckDuplicateEmailView.as_view())
+    path('/check_duplicate', CheckDuplicateEmailView.as_view()),
+    path('/password_reset', PasswordResetView.as_view())
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,10 +1,10 @@
 from django.urls import path
 
-from users.views import PasswordResetView, SignUpView, LoginView, CheckDuplicateEmailView
+from users.views import PasswordChangeView, SignUpView, LoginView, CheckDuplicateEmailView
 
 urlpatterns = [
     path('/signup', SignUpView.as_view()),
     path('/login', LoginView.as_view()),
     path('/check_duplicate', CheckDuplicateEmailView.as_view()),
-    path('/password_reset', PasswordResetView.as_view())
+    path('/password_change', PasswordChangeView.as_view())
 ]

--- a/users/utils.py
+++ b/users/utils.py
@@ -1,14 +1,22 @@
 import jwt
+import re
 
 from datetime import datetime, timedelta
 
 from django.conf     import settings
 from django.http     import JsonResponse
 from django.db.utils import IntegrityError
+from django.forms    import ValidationError
 
 from users.models import CustomUser
 
 class Validation:
+    def validate_password(self, password):
+        REGEX_PASSWORD = '^(?=.*\d)(?=.*[a-zA-Z])[0-9a-zA-Z]{8,}$'
+
+        if not re.match(REGEX_PASSWORD, password):
+            raise ValidationError('Enter a valid password.')
+
     def check_duplicate_email(self, email):
         if CustomUser.objects.filter(email = email).exists():
             raise IntegrityError

--- a/users/views.py
+++ b/users/views.py
@@ -104,7 +104,7 @@ class PasswordResetView(View, Validation):
             user.save()
             return JsonResponse({
                 'message' : 'PASSWORD_CHANGED_SUCCESSFULLY',
-                'user_name'   : user.name,
+                'email'   : user.email,
                 'new_password' : new_password,
                 }, status=201) 
         except ObjectDoesNotExist:

--- a/users/views.py
+++ b/users/views.py
@@ -108,6 +108,6 @@ class PasswordResetView(View, Validation):
                 'new_password' : new_password,
                 }, status=201) 
         except ObjectDoesNotExist:
-            return JsonResponse({'message' : 'NO_USER_EXISTS_WITH_THIS_EMAIL'}, status=400)
+            return JsonResponse({'message' : 'NO_USER_EXISTS_WITH_THIS_EMAIL'}, status=404)
         except ValidationError as e:
             return JsonResponse({'message' : e.message}, status=400)

--- a/users/views.py
+++ b/users/views.py
@@ -92,12 +92,12 @@ class CheckDuplicateEmailView(View, Validation):
         except KeyError:
             return JsonResponse({'message' : 'KEY_ERROR'}, status = 400)
 
-class PasswordResetView(View, Validation):
+class PasswordChangeView(View, Validation):
     def post(self, request):
         data            = json.loads(request.body)
         email           = data['email']
         old_password    = data['old_password']
-        new_password    = data['password']
+        new_password    = data['new_password']
         try:
             user = CustomUser.objects.get(email=email)
             user.check_password(old_password)

--- a/users/views.py
+++ b/users/views.py
@@ -96,9 +96,11 @@ class PasswordResetView(View, Validation):
     def post(self, request):
         data            = json.loads(request.body)
         email           = data['email']
+        old_password    = data['old_password']
         new_password    = data['password']
         try:
             user = CustomUser.objects.get(email=email)
+            user.check_password(old_password)
             self.validate_password(new_password)
             user.set_password(new_password)
             user.save()


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
### - PasswordResetView
    - Change a password of a user directly without requiring the old password
       - Currently able to change through sending a "POST" request of new body material through Postman 
    - No front-end implementation; purely for database manipulation
    - Further implementation ideas:
       - Allow users to change their own password through email verification
       - Only allow admins to change passwords by requiring a special access token given to only superusers

<br />

## :: 테스트 코드 결과
### CMD Test when running "py manage.py test users"
<img width="600" alt="password_reset_test_results" src="https://user-images.githubusercontent.com/83613067/177512366-bc7207b8-2931-4ecc-9fac-0ee1610d05ce.PNG">

### Postman result:
<img width="600" alt="password_reset_postman_result" src="https://user-images.githubusercontent.com/83613067/177512356-2a46dc3b-ce88-4545-9917-f393e6b58e98.PNG">

