### PR TITLE
[Remove] 적용되지 않는 Method 삭제 (Remove unnecessary method from DoctorListView)

### DIFF
--- a/appointments/views.py
+++ b/appointments/views.py
@@ -8,8 +8,8 @@ from django.core.paginator      import Paginator, PageNotAnInteger, EmptyPage
 from django.db.models           import CharField, Value as V, Q, F
 from django.db.models.functions import Concat
 
-from users.utils  import login_decorator, DateTimeFormat
-from users.models import Department, Doctor, WorkingDay, WorkingTime
+from users.utils         import login_decorator, DateTimeFormat
+from users.models        import Department, Doctor, WorkingDay, WorkingTime
 from appointments.models import Appointment, AppointmentImage, UserAppointment
 
 class DepartmentsListView(View):
@@ -26,14 +26,13 @@ class DoctorListView(View):
     def get(self, request, department_id):
         try: 
             page    = request.GET.get('page', 1)
-            doctors = Doctor.objects.select_related('user', 'department', 'hospital').filter(department_id=department_id)\
-                .annotate(
-                    doctor_id          = F('id'),
-                    doctor_name        = F('user__name'),
-                    doctor_department  = F('department__name'),
-                    doctor_hospital    = F('hospital__name'),
-                    doctor_profile_img = Concat(V(f'{settings.LOCAL_PATH}/doctor_profile_img/'), 'profile_img', output_field=CharField())
-                ).values('doctor_id', 'doctor_name', 'doctor_department', 'doctor_hospital', 'doctor_profile_img').order_by('id')
+            doctors = Doctor.objects.filter(department_id=department_id).annotate(
+                doctor_id          = F('id'),
+                doctor_name        = F('user__name'),
+                doctor_department  = F('department__name'),
+                doctor_hospital    = F('hospital__name'),
+                doctor_profile_img = Concat(V(f'{settings.LOCAL_PATH}/doctor_profile_img/'), 'profile_img', output_field=CharField())
+            ).values('doctor_id', 'doctor_name', 'doctor_department', 'doctor_hospital', 'doctor_profile_img').order_by('id')
 
             doctors_paginator = Paginator(doctors, 6).page(page).object_list
 

--- a/users/views.py
+++ b/users/views.py
@@ -82,7 +82,7 @@ class LoginView(View, Validation):
 class CheckDuplicateEmailView(View, Validation):
     def post(self, request):
         try:
-            data = json.loads(request.body)
+            data  = json.loads(request.body)
             email = data['email']
             self.check_duplicate_email(email)
             


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [x] 컨벤션 수정

<br />

## :: 구현 목표 
### - 적용되지 않는 Method 'select_related' 제거
- 'values()'를 사용하면 Django QuerySet 특성인 Eager-Loading 옵션을 전부 무시하게됨
- 이 경우에는 'select_related'를 사용하더라도 JOIN하지 않고, 그냥 무시함
- 객체와 관계지향 간에 매핑이 일어나지 않기 때문에 DB Row 단위로 데이터를 반환하는 'values()'에는 'select_related'가 무의미함

